### PR TITLE
Version 1.1.23 2019-09-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- the topmost header version must be set manually in the VERSION file -->
+### Version 1.1.23 2019-09-16
+- Improved Configuration-dictionary lookup to be case-independent
+- VersionTable will now consider whether SchemPrefixId is defined in the configuration 
+-  i.e: SchemPrefixId = EX => VersionTable will be EXVersion
+-  i.e: SchemPrefixId is unspicified => VersionTable will be Version
+- SchemaPrefixId is fetched from database:migration:schemaPrefix:id OR database:schemaPrefix:id
+- SchemaPrefixUniqueId is fetched from database:migration:schemaPrefix:UniqueId OR database:schemaPrefix:UniqueId
+- Improved how data in ChangeLogContext initialized.
+- Added LogFileAppendFluentMigratorLoggerProvider. Sql log can be added to the end of a existing file
+
 ### Version 1.1.22 2019-09-12
 - Improved how external oracle sql statements is executed
 

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Common.Abstractions/CommonAbstractionExtensions.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Common.Abstractions/CommonAbstractionExtensions.cs
@@ -132,6 +132,32 @@ namespace FluentDbTools.Common.Abstractions
             return sql.Trim().StartsWith("-- ") || sql.Trim().StartsWith("/*");
         }
 
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dictionary"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public static string GetValue(this IDictionary<string, string> dictionary, string key)
+        {
+            if (dictionary == null)
+            {
+                return null;
+            }
+
+            if (dictionary.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            if ((dictionary as Dictionary<string, string>)?.Comparer != null)
+            {
+                return null;
+            }
+            var e = dictionary.FirstOrDefault(x => StringExtensions.EqualsIgnoreCase(x.Key, key));
+            return e.Value;
+        }
     }
 
     

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Common.Abstractions/IDbConfigDatabaseTargets.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Common.Abstractions/IDbConfigDatabaseTargets.cs
@@ -27,5 +27,12 @@ namespace FluentDbTools.Common.Abstractions
         /// </summary>
         /// <returns></returns>
         string GetSchemaPrefixId();
+
+        /// <summary>
+        /// Can be used to specifying a unique Id for the <see cref="IDbConfigDatabaseTargets.GetSchemaPrefixId"/>
+        /// </summary>
+        /// <returns></returns>
+        string GetSchemaPrefixUniqueId();
+
     }
 }

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/ExtendedExpressions/IChangeLogTabledExpression.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/ExtendedExpressions/IChangeLogTabledExpression.cs
@@ -34,7 +34,7 @@ namespace FluentDbTools.Migration.Abstractions.ExtendedExpressions
         IList<ColumnDefinition> Columns { get; }
 
         /// <summary>
-        /// The Table columns (if any) for this Table-Change-Log operation
+        /// The context information for this Table-Change-Log operation
         /// </summary>
         ChangeLogContext ChangeLogContext { get; }
 

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/ICustomMigrationProcessor.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/ICustomMigrationProcessor.cs
@@ -31,7 +31,6 @@ namespace FluentDbTools.Migration.Abstractions
         /// <param name="expression"></param>
         void Process(IChangeLogTabledExpression expression);
 
-
         /// <summary>
         /// Will be called just after the Schema is created<br/>
         /// Can be used to execute custom grants or other database operations.

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/IDbMigrationConfig.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/IDbMigrationConfig.cs
@@ -54,11 +54,5 @@ namespace FluentDbTools.Migration.Abstractions
         /// GetAllMigrationConfigValues() : Get al values and subValues from configuration "database:migration". 
         /// </summary>
         IDictionary<string, string> GetAllMigrationConfigValues(bool reload = false);
-
-        /// <summary>
-        /// Can be used to specifying a unique Id for the <see cref="IDbConfigDatabaseTargets.GetSchemaPrefixId"/>
-        /// </summary>
-        /// <returns></returns>
-        string GetSchemaPrefixUniqueId();
     }
 }

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/IFluentDbToolsVersionTableMetaData.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/IFluentDbToolsVersionTableMetaData.cs
@@ -1,0 +1,10 @@
+﻿using FluentMigrator.Runner.VersionTableInfo;
+
+namespace FluentDbTools.Migration.Abstractions
+{
+    /// <inheritdoc />
+    public interface IFluentDbToolsVersionTableMetaData : IVersionTableMetaData
+    {
+
+    }
+}

--- a/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/IMigrationModel.cs
+++ b/src/FluentDbTools/Abstractions/FluentDbTools.Migration.Abstractions/IMigrationModel.cs
@@ -17,9 +17,15 @@ namespace FluentDbTools.Migration.Abstractions
         string SchemaName { get; }
 
         /// <summary>
-        /// SchemaPrefixId from configuration "database:migration:schemaprefix:id"
+        /// SchemaPrefixId - Fetch value from configuration "database:migration:schemaprefix:id" or "database:database:schemaprefix:id"
         /// </summary>
         string SchemaPrefixId { get; }
+
+        /// <summary>
+        /// SchemaPrefixUniqueId - Fetch value from configuration "database:migration:schemaprefix:uniqueid" or "database:database:schemaprefix:uniqueid"
+        /// </summary>
+        string SchemaPrefixUniqueId { get; }
+
 
         /// <summary>
         /// Return the injected MigrationContext or it will be resolved by reflection

--- a/src/FluentDbTools/Contracts/FluentDbTools.Contracts/DbConfigDatabaseTargets.cs
+++ b/src/FluentDbTools/Contracts/FluentDbTools.Contracts/DbConfigDatabaseTargets.cs
@@ -3,52 +3,71 @@ using FluentDbTools.Common.Abstractions;
 
 namespace FluentDbTools.Contracts
 {
+    /// <inheritdoc />
     public class DbConfigDatabaseTargets : IDbConfigDatabaseTargets
     {
-        public DefaultDbConfigValues Defaults { get; protected set; }
+        private SupportedDatabaseTypes? DbTypeField;
+        private string SchemaField;
+        private string DatabaseConnectionNameField;
+        private string SchemaPrefixUniqueIdField;
 
+        /// <summary>
+        /// All default values
+        /// </summary>
+        public DefaultDbConfigValues Defaults { get; protected set; }
+        
         protected string ScemaPrefixIdField { get; set; }
+        /// <summary>
+        /// Constructor 
+        /// </summary>
+        /// <param name="defaultDbConfigValues"></param>
         public DbConfigDatabaseTargets(DefaultDbConfigValues defaultDbConfigValues = null)
         {
             Defaults = defaultDbConfigValues ?? new DefaultDbConfigValues();
         }
 
 
-        protected SupportedDatabaseTypes? DbTypeBacking { get; set; }
+        /// <inheritdoc />
         public virtual SupportedDatabaseTypes DbType
         {
-            get => DbTypeBacking ?? Defaults.GetDefaultDbType?.Invoke() ?? DefaultDbConfigValues.DefaultDbType;
-            set => DbTypeBacking = value;
+            get => DbTypeField ?? Defaults.GetDefaultDbType?.Invoke() ?? DefaultDbConfigValues.DefaultDbType;
+            set => DbTypeField = value;
         }
 
-        private string SchemaField;
+        /// <inheritdoc />
         public virtual string Schema
         {
             get => SchemaField ?? Defaults.GetDefaultSchema?.Invoke();
             set => SchemaField = value;
         }
 
-        private string DatabaseConnectionNameField;
+        /// <inheritdoc />
         public virtual string DatabaseName
         {
             get => DatabaseConnectionNameField ?? Defaults.GetDefaulDatabaseName?.Invoke();
             set => DatabaseConnectionNameField = value;
         }
 
+        /// <inheritdoc />
         public virtual string GetSchemaPrefixId() => ScemaPrefixIdField ?? Defaults.GetDefaultSchemaPrefixIdString();
+
+        /// <inheritdoc />
+        public virtual string GetSchemaPrefixUniqueId() => SchemaPrefixUniqueIdField ?? Defaults.GetDefaultSchemaPrefixUniqueIdString();
 
         public static DbConfigDatabaseTargets Create(
             SupportedDatabaseTypes dbType, 
             string schema,
             string databaseName = null,
-            string schemaPrefixId = null)
+            string schemaPrefixId = null,
+            string schemaPrefixUniqueId = null)
         {
             return new DbConfigDatabaseTargets()
             {
                 DbType = dbType,
                 Schema = schema,
                 DatabaseName = databaseName,
-                ScemaPrefixIdField = schemaPrefixId
+                ScemaPrefixIdField = schemaPrefixId,
+                SchemaPrefixUniqueIdField =  schemaPrefixUniqueId
             };
         }
     }

--- a/src/FluentDbTools/Contracts/FluentDbTools.Contracts/DefaultDbConfigValues.cs
+++ b/src/FluentDbTools/Contracts/FluentDbTools.Contracts/DefaultDbConfigValues.cs
@@ -30,6 +30,7 @@ namespace FluentDbTools.Contracts
         public Func<string> GetDefaultAdminConnectionString = () => null;
 
         public Func<string> GetDefaultSchemaPrefixIdString = () => string.Empty;
+        public Func<string> GetDefaultSchemaPrefixUniqueIdString = () => string.Empty;
 
     }
 }

--- a/src/FluentDbTools/Contracts/FluentDbTools.Migration.Contracts/MigrationModel.cs
+++ b/src/FluentDbTools/Contracts/FluentDbTools.Migration.Contracts/MigrationModel.cs
@@ -19,6 +19,7 @@ namespace FluentDbTools.Migration.Contracts
     {
         private string SchemaNameField;
         private string SchemaPrefixIdField;
+        private string SchemaPrefixUniqueIdField;
         private string ConfiguredDatabaseTypeField;
         private IVersionTableMetaData Version;
         private IMigrationContext MigrationContextField;
@@ -105,6 +106,21 @@ namespace FluentDbTools.Migration.Contracts
 
                 SchemaPrefixIdField = GetMigrationConfig()?.GetSchemaPrefixId();
                 return SchemaPrefixIdField;
+            }
+        }
+
+        /// <inheritdoc />
+        public string SchemaPrefixUniqueId
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(SchemaPrefixUniqueIdField))
+                {
+                    return SchemaPrefixUniqueIdField;
+                }
+
+                SchemaPrefixUniqueIdField = GetMigrationConfig()?.GetSchemaPrefixUniqueId();
+                return SchemaPrefixUniqueIdField;
             }
         }
 

--- a/src/FluentDbTools/Example/Example.FluentDbTools.Database/Table.cs
+++ b/src/FluentDbTools/Example/Example.FluentDbTools.Database/Table.cs
@@ -4,5 +4,6 @@
     {
         public const string Person = nameof(Entities.Person);
         public const string Parent = nameof(Entities.Parent);
+        public const string Testing = "Testing";
     }
 }

--- a/src/FluentDbTools/Example/Example.FluentDbTools.Migration/ExampleVersionTable.cs
+++ b/src/FluentDbTools/Example/Example.FluentDbTools.Migration/ExampleVersionTable.cs
@@ -1,22 +1,22 @@
-﻿using FluentDbTools.Common.Abstractions;
+﻿using System.Runtime.CompilerServices;
+using FluentDbTools.Common.Abstractions;
 using FluentDbTools.Migration.Abstractions;
-using FluentMigrator.Runner.VersionTableInfo;
+using FluentDbTools.Migration.Common;
 
 #pragma warning disable 618
-
+[assembly:InternalsVisibleTo("Test.FluentDbTools.Migration")]
 namespace Example.FluentDbTools.Migration
 {
-    public class ExampleVersionTable : DefaultVersionTableMetaData
+    /// <inheritdoc />
+    internal class ExampleVersionTableMetaData : VersionTableMetaData
     {
-        private readonly IDbMigrationConfig DbMigrationConfig;
-        
-        public ExampleVersionTable(IDbMigrationConfig dbMigrationConfig) 
+        /// <inheritdoc />
+        public ExampleVersionTableMetaData(IDbMigrationConfig dbMigrationConfig) 
+            : base(dbMigrationConfig)
         {
-            DbMigrationConfig = dbMigrationConfig;
         }
 
-        public override string UniqueIndexName => "UC_" + TableName;
-        public override string TableName => nameof(ExampleVersionTable).GetPrefixedName(DbMigrationConfig.GetSchemaPrefixId());
-        public override string SchemaName => DbMigrationConfig.Schema;
+        /// <inheritdoc />
+        public override string TableName => nameof(ExampleVersionTableMetaData).GetPrefixedName(DbMigrationConfig.GetSchemaPrefixId());
     }
 }

--- a/src/FluentDbTools/Extensions/FluentDbTools.Extensions.MSDependencyInjection/DefaultConfigs/MsDbConfig.cs
+++ b/src/FluentDbTools/Extensions/FluentDbTools.Extensions.MSDependencyInjection/DefaultConfigs/MsDbConfig.cs
@@ -1,14 +1,17 @@
 ﻿using System.Collections.Generic;
+using FluentDbTools.Common.Abstractions;
 using FluentDbTools.Contracts;
 using FluentDbTools.Extensions.DbProvider;
 using Microsoft.Extensions.Configuration;
 
 namespace FluentDbTools.Extensions.MSDependencyInjection.DefaultConfigs
 {
+    /// <inheritdoc />
     public class MsDbConfig : DbConfig
     {
         private readonly IConfiguration Configuration;
 
+        /// <inheritdoc />
         public MsDbConfig(
             IConfiguration configuration, 
             MsDefaultDbConfigValues defaultDbConfigValues = null) :
@@ -26,12 +29,21 @@ namespace FluentDbTools.Extensions.MSDependencyInjection.DefaultConfigs
 
             return AllConfigValuesField;
         }
-            
 
+
+        /// <inheritdoc />
         public override string GetSchemaPrefixId()
         {
             return GetAllDatabaseConfigValues().GetValue("schemaPrefix:Id") ??
                    Defaults.GetDefaultSchemaPrefixIdString?.Invoke() ?? string.Empty;
         }
+
+        /// <inheritdoc />
+        public override string GetSchemaPrefixUniqueId()
+        {
+            return GetAllDatabaseConfigValues().GetValue("schemaPrefix:UniqueId") ??
+                   Defaults.GetDefaultSchemaPrefixUniqueIdString?.Invoke() ?? string.Empty;
+        }
+
     }
 }

--- a/src/FluentDbTools/Extensions/FluentDbTools.Extensions.MSDependencyInjection/DefaultConfigs/MsDbConfigExtensions.cs
+++ b/src/FluentDbTools/Extensions/FluentDbTools.Extensions.MSDependencyInjection/DefaultConfigs/MsDbConfigExtensions.cs
@@ -184,7 +184,7 @@ namespace FluentDbTools.Extensions.MSDependencyInjection.DefaultConfigs
         public static IDictionary<string, string> GetDbAllConfigValues(
             this IConfigurationSection sections)
         {
-            var dictionary = new Dictionary<string, string>();
+            var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (sections == null)
             {
                 return dictionary;
@@ -213,16 +213,6 @@ namespace FluentDbTools.Extensions.MSDependencyInjection.DefaultConfigs
             }
 
             return dictionary;
-        }
-        public static string GetValue(this IDictionary<string, string> dictionary, string key)
-        {
-            string value = null;
-            if (dictionary?.TryGetValue(key, out value) ?? false)
-            {
-                return value;
-            }
-
-            return null;
         }
     }
 }

--- a/src/FluentDbTools/Extensions/FluentDbTools.Extensions.Migration/DefaultConfigs/MsDbMigrationConfig.cs
+++ b/src/FluentDbTools/Extensions/FluentDbTools.Extensions.Migration/DefaultConfigs/MsDbMigrationConfig.cs
@@ -83,7 +83,9 @@ namespace FluentDbTools.Extensions.Migration.DefaultConfigs
         public string DatabaseName => GetDbConfig().DatabaseName;
 
         /// <inheritdoc />
-        public string GetSchemaPrefixId() => GetAllMigrationConfigValues().GetValue("schemaPrefix:Id") ?? Defaults?.GetDefaultSchemaPrefixIdString.Invoke() ?? string.Empty;
+        public string GetSchemaPrefixId() => GetAllMigrationConfigValues().GetValue("schemaPrefix:Id") ?? 
+                                             GetDbConfig().GetSchemaPrefixId() ??   
+                                             Defaults?.GetDefaultSchemaPrefixIdString.Invoke() ?? string.Empty;
 
         /// <inheritdoc />
         public string DatabaseOwner => Configuration.GetMigrationDatabaseOwner() ?? GetDbConfig().AdminUser;
@@ -108,7 +110,9 @@ namespace FluentDbTools.Extensions.Migration.DefaultConfigs
         /// <inheritdoc />
         public string GetSchemaPrefixUniqueId()
         {
-            return GetAllMigrationConfigValues().GetValue("schemaPrefix:UniqueId");
+            return GetAllMigrationConfigValues().GetValue("schemaPrefix:UniqueId") ??
+                   GetDbConfig().GetSchemaPrefixUniqueId() ??
+                   Defaults?.GetDefaultSchemaPrefixUniqueIdString.Invoke() ?? string.Empty;;
         }
     }
 }

--- a/src/FluentDbTools/FluentDbTools.sln.DotSettings
+++ b/src/FluentDbTools/FluentDbTools.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DIPSID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LONGPREFIX/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OPPRETTETAV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OPPRETTETTID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SISTENDRETAV/@EntryIndexedValue">True</s:Boolean>

--- a/src/FluentDbTools/Implementations/FluentDbTools.Migration.Common/ServiceRegistration.cs
+++ b/src/FluentDbTools/Implementations/FluentDbTools.Migration.Common/ServiceRegistration.cs
@@ -1,4 +1,5 @@
-﻿using FluentMigrator.Runner.VersionTableInfo;
+﻿using FluentDbTools.Migration.Abstractions;
+using FluentMigrator.Runner.VersionTableInfo;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FluentDbTools.Migration.Common
@@ -8,7 +9,8 @@ namespace FluentDbTools.Migration.Common
         public static IServiceCollection Register(IServiceCollection serviceCollection)
         {
             return serviceCollection
-                .AddScoped<IVersionTableMetaData, VersionTable>();
+                .AddScoped<IFluentDbToolsVersionTableMetaData, VersionTableMetaData>()
+                .AddScoped<IVersionTableMetaData>(sp => sp.GetRequiredService<IFluentDbToolsVersionTableMetaData>());
         }
     }
 }

--- a/src/FluentDbTools/Implementations/FluentDbTools.Migration.Common/VersionTable.cs
+++ b/src/FluentDbTools/Implementations/FluentDbTools.Migration.Common/VersionTable.cs
@@ -1,22 +1,58 @@
-﻿using FluentDbTools.Common.Abstractions;
+﻿using System.Runtime.CompilerServices;
+using FluentDbTools.Common.Abstractions;
 using FluentDbTools.Migration.Abstractions;
 using FluentMigrator.Runner.Conventions;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.VersionTableInfo;
 using Microsoft.Extensions.Options;
 #pragma warning disable 618
-
+[assembly:InternalsVisibleTo("Example.FluentDbTools.Migration")]
 namespace FluentDbTools.Migration.Common
 {
-    internal class VersionTable : DefaultVersionTableMetaData
+    /// <summary>
+    /// Default implementation of VersionTable
+    /// </summary>
+    internal class VersionTableMetaData : DefaultVersionTableMetaData, IFluentDbToolsVersionTableMetaData
     {
-        private readonly IDbMigrationConfig DbConfig;
+        /// <summary>
+        /// The migration config
+        /// </summary>
+        protected readonly IDbMigrationConfig DbMigrationConfig;
 
-        public VersionTable(IDbMigrationConfig dbConfig)
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="dbMigrationConfig"></param>
+        public VersionTableMetaData(IDbMigrationConfig dbMigrationConfig)
         {
-            DbConfig = dbConfig;
+            DbMigrationConfig = dbMigrationConfig;
         }
+        /// <summary>
+        /// Then name of UniqueIndexName <br/>
+        /// Default if no schemaPrefix will be UC_Version.<br/>
+        /// With schemaPrefix specified, the UniqueIndexName will be {schemaPrefix}UC_Version<br/>
+        /// <br/>
+        /// i.e:<br/>
+        /// When schemaPrefix is null, the UniqueIndexName will be UC_Version<br/>
+        /// When schemaPrefix = "EX", the UniqueIndexName will be EXUC_Version<br/>
+        /// </summary>
+        public override string UniqueIndexName => base.UniqueIndexName.GetPrefixedName(DbMigrationConfig.GetSchemaPrefixId());
         
-        public override string SchemaName => DbConfig.Schema;
+        /// <summary>
+        /// Then name of Version TableName <br/>
+        /// Default if no schemaPrefix will be VersionInfo.<br/>
+        /// With schemaPrefix specified, the UniqueIndexName will be {schemaPrefix}VersionInfo<br/>
+        /// <br/>
+        /// i.e:<br/>
+        /// When schemaPrefix is null, the UniqueIndexName will be VersionInfo<br/>
+        /// When schemaPrefix = "EX", the UniqueIndexName will be EXVersionInfo<br/>
+        /// </summary>
+        public override string TableName => base.TableName.GetPrefixedName(DbMigrationConfig.GetSchemaPrefixId());
+
+        /// <summary>
+        /// SchemaPrefix will be fetched from <see cref="DbMigrationConfig"/>.Schema
+        /// </summary>
+        public override string SchemaName => DbMigrationConfig.Schema;
+
     }
 }

--- a/src/FluentDbTools/Implementations/FluentDbTools.Migration/FluentMigrationLoggingExtensions.cs
+++ b/src/FluentDbTools/Implementations/FluentDbTools.Migration/FluentMigrationLoggingExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using FluentDbTools.Extensions.MSDependencyInjection;
 using FluentMigrator.Runner;
-using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +11,14 @@ namespace FluentDbTools.Migration
 {
     public static class FluentMigrationLoggingExtensions
     {
+        public static bool UseLogFileAppendFluentMigratorLoggerProvider { get; set; }
+        public static IServiceCollection AddLogFileAppendFluentMigratorLoggerProvider(this IServiceCollection sc)
+        {
+            sc.Remove(new ServiceDescriptor(typeof(ILoggerProvider), typeof(LogFileFluentMigratorLoggerProvider)));
+            sc.AddScoped<ILoggerProvider, LogFileAppendFluentMigratorLoggerProvider>();
+            return sc;
+        }
+
         /// <summary>
         /// Remove all log-providers and add FluentMigratorConsoleLoggerProvider if enabled by configuration
         /// </summary>
@@ -56,7 +62,7 @@ namespace FluentDbTools.Migration
             }
 
             loggingBuilder.Services.AddSingleton<IOptions<FluentMigratorLoggerOptions>>(new OptionsWrapper<FluentMigratorLoggerOptions>(options));
-            loggingBuilder.Services.AddSingleton<ILoggerProvider, FluentMigratorConsoleLoggerProvider>();
+            loggingBuilder.Services.AddScoped<ILoggerProvider, FluentMigratorConsoleLoggerProvider>();
 
             return loggingBuilder;
         }
@@ -106,7 +112,16 @@ namespace FluentDbTools.Migration
             }
 
             loggingBuilder.Services.AddSingleton<IOptions<LogFileFluentMigratorLoggerOptions>>(new OptionsWrapper<LogFileFluentMigratorLoggerOptions>(options));
-            loggingBuilder.Services.AddSingleton<ILoggerProvider, LogFileFluentMigratorLoggerProvider>();
+            if (UseLogFileAppendFluentMigratorLoggerProvider)
+            {
+                loggingBuilder.Services.AddLogFileAppendFluentMigratorLoggerProvider();
+
+            }
+            else
+            {
+                loggingBuilder.Services.AddScoped<ILoggerProvider, LogFileFluentMigratorLoggerProvider>();
+
+            }
             return loggingBuilder;
         }
 

--- a/src/FluentDbTools/Implementations/FluentDbTools.Migration/LogFileAppendFluentMigratorLoggerProvider.cs
+++ b/src/FluentDbTools/Implementations/FluentDbTools.Migration/LogFileAppendFluentMigratorLoggerProvider.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using FluentMigrator.Runner.Initialization;
+using FluentMigrator.Runner.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FluentDbTools.Migration
+{
+    /// <summary>
+    /// Append the SQL statements to then end of a log file
+    /// </summary>
+    public class LogFileAppendFluentMigratorLoggerProvider : SqlScriptFluentMigratorLoggerProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogFileAppendFluentMigratorLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="assemblySource">The assembly source</param>
+        /// <param name="options">The log file logger options</param>
+        /// <param name="disposeWriter">A value indicating whether the internal writer should be disposed by this logger provider</param>
+        public LogFileAppendFluentMigratorLoggerProvider(
+                IAssemblySource assemblySource,
+                IOptions<LogFileFluentMigratorLoggerOptions> options,
+                bool disposeWriter = true)
+            : base(new StreamWriter(GetOutputFileName(assemblySource, options.Value), true, Encoding.UTF8), options.Value, disposeWriter)
+        {
+        }
+        private static string GetOutputFileName(
+            IAssemblySource assemblySource,
+            LogFileFluentMigratorLoggerOptions options)
+        {
+            if (!string.IsNullOrEmpty(options.OutputFileName))
+                return options.OutputFileName;
+
+            if (assemblySource.Assemblies.Count == 0)
+                return "fluentmigrator.sql";
+
+            var assembly = assemblySource.Assemblies.First();
+            return assembly.Location + ".sql";
+        }
+
+    }
+}


### PR DESCRIPTION
- Improved Configuration-dictionary lookup to be case-independent
- VersionTable will now consider whether SchemPrefixId is defined in the configuration 
-  i.e: SchemPrefixId = EX => VersionTable will be EXVersion
-  i.e: SchemPrefixId is unspicified => VersionTable will be Version
- SchemaPrefixId is fetched from database:migration:schemaPrefix:id OR database:schemaPrefix:id
- SchemaPrefixUniqueId is fetched from database:migration:schemaPrefix:UniqueId OR database:schemaPrefix:UniqueId
- Improved how data in ChangeLogContext initialized.
- Added LogFileAppendFluentMigratorLoggerProvider. Sql log can be added to the end of a existing file