### PR TITLE
Version 1.2.26 2021-11-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- the topmost header version must be set manually in the VERSION file -->
+### Version 1.2.26 2021-11-05
+- Improved LogFileAppendFluentMigratorLoggerProvider. 
+  If logfile is already open, change logfile to a filename with timestamp - ex. "abcd.log" => "abcd-20211105.log"
 
 ### Version 1.2.25 2021-06-17
 - Added openConnectionWhenRequest parameter to ServiceCollectionDbProviderExtensions:AddDbProvider method

--- a/src/FluentDbTools/Tests/Test.FluentDbTools.DbProvider/OracleConnectionStringBuilderTests.cs
+++ b/src/FluentDbTools/Tests/Test.FluentDbTools.DbProvider/OracleConnectionStringBuilderTests.cs
@@ -157,7 +157,7 @@ namespace Test.FluentDbTools.DbProvider
                 using (var connection = dbConfig.GetDbProviderFactory(true).CreateConnection())
                 {
                     connection.DataSource.Should().Be(expectedDataSource);
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
 
@@ -180,7 +180,7 @@ namespace Test.FluentDbTools.DbProvider
                 using (var oracleConnection = dbConfig.GetDbProviderFactory(true).CreateConnection())
                 {
                     oracleConnection.DataSource.Should().Be(expectedDataSource);
-                    oracleConnection.Open();
+                    oracleConnection.SafeOpen();
                 }
             };
 
@@ -255,7 +255,7 @@ namespace Test.FluentDbTools.DbProvider
             {
                 using (var connection = new OracleConnection(connectionString))
                 {
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
 
@@ -275,7 +275,7 @@ namespace Test.FluentDbTools.DbProvider
             {
                 using (var connection = new OracleConnection(connectionString))
                 {
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
 
@@ -296,7 +296,7 @@ namespace Test.FluentDbTools.DbProvider
             {
                 using (var connection = new OracleConnection(connectionString))
                 {
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
 
@@ -317,7 +317,7 @@ namespace Test.FluentDbTools.DbProvider
             {
                 using (var connection = new OracleConnection(connectionString))
                 {
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
 
@@ -343,7 +343,7 @@ namespace Test.FluentDbTools.DbProvider
             {
                 using (var connection = new OracleConnection(connectionString))
                 {
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
             // ORA-12514: TNS:listener does not currently know of service requested in connect descriptor
@@ -363,7 +363,7 @@ namespace Test.FluentDbTools.DbProvider
             {
                 using (var connection = new OracleConnection(connectionString))
                 {
-                    connection.Open();
+                    connection.SafeOpen();
                 }
             };
 

--- a/src/FluentDbTools/Tests/Test.FluentDbTools.Migration/LogFileAppendFluentMigratorLoggerProviderTests.cs
+++ b/src/FluentDbTools/Tests/Test.FluentDbTools.Migration/LogFileAppendFluentMigratorLoggerProviderTests.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions;
+using FluentDbTools.Migration;
+using FluentMigrator.Runner.Logging;
+using Xunit;
+
+namespace Test.FluentDbTools.Migration
+{
+    public class LogFileAppendFluentMigratorLoggerProviderTests
+    {
+        [Fact]
+        public void GetStreamWriter()
+        {
+
+            var options = new LogFileFluentMigratorLoggerOptions() { OutputFileName = "abcd.log"};
+            var streamWriter1 = LogFileAppendFluentMigratorLoggerProvider.GetStreamWriter(null, options, out var logFile);
+            streamWriter1.Should().NotBeNull();
+            logFile.Should().EndWith(options.OutputFileName);
+            for (var i = 0; i < 10; i++)
+            {
+                var streamWriter2 = LogFileAppendFluentMigratorLoggerProvider.GetStreamWriter(null, options, out logFile);
+                streamWriter2.Should().NotBeNull();
+                logFile.Should().NotEndWith(options.OutputFileName);
+            }
+
+            streamWriter1.Close();
+
+            var streamWriter3 = LogFileAppendFluentMigratorLoggerProvider.GetStreamWriter(null, options, out logFile);
+            streamWriter3.Should().NotBeNull();
+            logFile.Should().EndWith(options.OutputFileName);
+
+        }
+    }
+}


### PR DESCRIPTION
- Improved LogFileAppendFluentMigratorLoggerProvider. 
  If logfile is already open, change logfile to a filename with timestamp - ex. "abcd.log" => "abcd-20211105.log"